### PR TITLE
feat(repo): paginate tasks list by user with per-page option

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -22,7 +22,7 @@ private TaskRepositoryInterface $TaskRepository;
     {
              try {
                 $userId = auth()->id();
-             $all_task = $this->TaskRepository->getAllByUser($userId);
+             $all_task = $this->TaskRepository->getAllByUser($userId, 10);
                    return TaskResource::collection($all_task);
                } catch (\Exception $e) {
             return response()->json([

--- a/app/Repositories/Interfaces/TaskRepositoryInterface.php
+++ b/app/Repositories/Interfaces/TaskRepositoryInterface.php
@@ -4,7 +4,7 @@ namespace App\Repositories\Interfaces;
 
 interface TaskRepositoryInterface
 {
-    public function getAllByUser($userId);
+    public function getAllByUser($userId,$perPage);
     public function getById($id);
     public function create(array $attributes);
     public function update($id, array $attributes);

--- a/app/Repositories/TaskRepository.php
+++ b/app/Repositories/TaskRepository.php
@@ -7,9 +7,9 @@ use App\Models\Task; // Assumption: You have a Model with the same name
 
 class TaskRepository implements TaskRepositoryInterface
 {
-    public function getAllByUser($userId)
+    public function getAllByUser($userId, $perPage = 10)
     {
-      return Task::where('user_id', $userId)->get();
+        return Task::where('user_id', $userId)->paginate($perPage);
     }
 
     public function getById($id)


### PR DESCRIPTION
Add pagination support when fetching tasks for a user. Update the TaskRepository getAllByUser method to accept a perPage parameter (default 10) and return a paginated result instead of all records. Adjust the TaskRepositoryInterface signature to include the perPage parameter. Update TaskController to pass a per-page value (10) when requesting the user's tasks.

This reduces memory usage and response size for large task sets and enables consistent paging behavior for API consumers.